### PR TITLE
feat: Attempt for a workflow to automatically approve dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,22 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#automatically-approving-a-pull-request
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.3.0
+        with:
+          github-token: ${{ secrets.DEPENDABOT_AUTO_APPROVE_TOKEN }}
+      - name: Approve the pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTO_APPROVE_TOKEN }}


### PR DESCRIPTION
# Work

We have a lot of automatic updates from `dependabot` every week. Most of the times those PRs are passing and we need to approve and merge them manually.

This could be streamlined. There are some good reasons why github does not allow this (see issue [#1973](https://github.com/dependabot/dependabot-core/issues/1973) in `dependabot`). This is currently not a big concern for our repositories and we decided to bypass this.

Based on what is proposed in this [Stack Overflow](https://stackoverflow.com/questions/64116781/how-do-i-automerge-dependabot-updates-config-version-2) post, we create a new workflow to automatically approve the PRs.

# Tests

The plan will be to test this with the next batch of dependabot PRs (which should happen tomorrow).

# Future work

If this works we could roll it out to other repositories. Additionally due to activating the branch protection rule we can't directly push to `master` anymore. This might prove a bit cumbersome and so maybe we could have a look at re-enabling it.
