### PR TITLE
chore: Attempt to fix the build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
+		"build": "svelte-kit sync && vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
# Work

When building the project we get a warning as follows:

<img width="905" height="555" alt="image" src="https://github.com/user-attachments/assets/d3ce061d-7648-444e-8f4f-a21608993978" />

See e.g. [this CI run](https://github.com/Knoblauchpilze/qwixx-sheet/actions/runs/16741718287/job/47391351938?pr=254).

According to issue [#5390](https://github.com/sveltejs/kit/issues/5390#issuecomment-2502040792) it seems to be due because the build step does not call `svelte-check sync`.

# Tests

With the changes in this PR, the warning is gone:

<img width="905" height="555" alt="image" src="https://github.com/user-attachments/assets/31fca04f-e292-4405-8706-bfcc54cb90f4" />

See e.g. [this CI run](https://github.com/Knoblauchpilze/qwixx-sheet/actions/runs/16741811814/job/47391603963).

# Future work

The same changes should be ported in other projects. At the very least in the `template-frontend` project.

Done in:
* [e904312](https://github.com/Knoblauchpilze/template-frontend/commit/e904312dd24e86c14ee1c8b5c7878b574f973ca6) for `template-frontend`
* [cc7cbc2](https://github.com/Knoblauchpilze/user-dashboard/commit/cc7cbc285ad7a2c529612da50e68db27f27dae19) for `user-dashboard`
* [ea1db20](https://github.com/Knoblauchpilze/galactic-sovereign-frontend/commit/ea1db202ff3ec76f16b588f601945bd6ac03475a) for `galactic-sovereign-frontend`
* [5991258](https://github.com/Knoblauchpilze/website-lobby/commit/5991258f458bc7d3596b89d7a70f4375dcb35f12) for `website-lobby`
* [35c899b](https://github.com/Knoblauchpilze/chat-app/commit/35c899bf196754bb8a7d2983e4b45da68930529d) for `chat-app`
* [9addfd2](https://github.com/Knoblauchpilze/frontend-toolkit/commit/9addfd281b5f8d55596b4679ba02f470b239e063) for `frontend-toolkit`
